### PR TITLE
Fix dark mode toggle

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title = "colin.cafe"
-baseURL = 'https://colin.cafe'
+baseURL = 'https://colin.cafe/'
 languageCode = 'fr-FR'
 theme = "hugo-blog-awesome"
 

--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,7 @@ enableEmoji = true
     url = '/'
     weight = 10
 
+[params]
   sitename = "colin.cafe"
   defaultColor = "light" # set default color mode: dark or light
   description = "description"

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 title = "colin.cafe"
-baseURL = 'https://colin.cafe/'
+baseURL = 'https://colin.cafe'
 languageCode = 'fr-FR'
 theme = "hugo-blog-awesome"
 


### PR DESCRIPTION
Hi colin, you just have to add `[params]` before `sitename = "colin.cafe"` in `config.toml`.

This PR tries to do just that.

I hope that solves your problem.